### PR TITLE
Fix hcalendar.location without hcalendar.location.adr

### DIFF
--- a/buildit.sh
+++ b/buildit.sh
@@ -3,12 +3,12 @@ if [ ! `which rsync` ] ; then
    exit 1
 fi
 
-if [ ! `which zip ] ; then
+if [ ! `which zip` ] ; then
    echo "Requires zip"
    exit 1
 fi
 
-if [ ! `which perl ] ; then
+if [ ! `which perl` ] ; then
    echo "Requires perl"
    exit 1
 fi

--- a/chrome/content/SemanticActions/30boxes.js
+++ b/chrome/content/SemanticActions/30boxes.js
@@ -63,9 +63,9 @@ var thirty_boxes_calendar = {
       }
       if (hcalendar.location) {
         url += "[";
-        if (typeof hcalendar.location == "object") {
+        if (typeof hcalendar.location == "object" && typeof hcalendar.location.adr == "object") {
           var j = 0;
-		  if (hcalendar.location.adr[j]) {
+          if (hcalendar.location.adr[j]) {
             if (hcalendar.location.adr[j]["street-address"]) {
               url += hcalendar.location.adr[j]["street-address"][0];
             }
@@ -85,7 +85,7 @@ var thirty_boxes_calendar = {
               url += ",";
               url += hcalendar.location.adr[j]["country-name"];
             }
-		  }
+          }
         } else {
           url += hcalendar.location;
         }

--- a/chrome/content/SemanticActions/google.js
+++ b/chrome/content/SemanticActions/google.js
@@ -199,30 +199,32 @@ var google_calendar = {
             url += encodeURIComponent(hcalendar.location.fn);
           }
 
-		      if (hcalendar.location.adr[j]) {
-            if (hcalendar.location.adr[j]["street-address"]) {
-              if (hcalendar.location.fn) {
-                url += ", ";
+          if (hcalendar.location.adr && typeof hcalendar.location.adr == "object") {
+            if (hcalendar.location.adr[j]) {
+              if (hcalendar.location.adr[j]["street-address"]) {
+                if (hcalendar.location.fn) {
+                  url += ", ";
+                }
+                url += encodeURIComponent(hcalendar.location.adr[j]["street-address"][0]);
               }
-              url += encodeURIComponent(hcalendar.location.adr[j]["street-address"][0]);
+              if (hcalendar.location.adr[j].locality) {
+                url += ", ";
+                url += encodeURIComponent(hcalendar.location.adr[j].locality);
+              }
+              if (hcalendar.location.adr[j].region) {
+                url += ", ";
+                url += encodeURIComponent(hcalendar.location.adr[j].region);
+              }
+              if (hcalendar.location.adr[j]["postal-code"]) {
+                url += " ";
+                url += hcalendar.location.adr[j]["postal-code"];
+              }
+              if (hcalendar.location.adr[j]["country-name"]) {
+                url += ",";
+                url += encodeURIComponent(hcalendar.location.adr[j]["country-name"]);
+              }
             }
-            if (hcalendar.location.adr[j].locality) {
-              url += ", ";
-              url += encodeURIComponent(hcalendar.location.adr[j].locality);
-            }
-            if (hcalendar.location.adr[j].region) {
-              url += ", ";
-              url += encodeURIComponent(hcalendar.location.adr[j].region);
-            }
-            if (hcalendar.location.adr[j]["postal-code"]) {
-              url += " ";
-              url += hcalendar.location.adr[j]["postal-code"];
-            }
-            if (hcalendar.location.adr[j]["country-name"]) {
-              url += ",";
-              url += encodeURIComponent(hcalendar.location.adr[j]["country-name"]);
-            }
-		      }
+          }
         } else {
           url += "&";
           url += "location=" + encodeURIComponent(hcalendar.location);

--- a/chrome/content/SemanticActions/yahoo.js
+++ b/chrome/content/SemanticActions/yahoo.js
@@ -216,24 +216,26 @@ var yahoo_calendar = {
           if (hcalendar.location.fn) {
             url += "in_loc=" + hcalendar.location.fn;
           }
-		  if (hcalendar.location.adr[j]) {
-             if (hcalendar.location.adr[j]["street-address"]) {
-               url += "&";
-               url += "in_st=" + encodeURIComponent(hcalendar.location.adr[j]["street-address"][0]);
-             }
-             if (hcalendar.location.adr[j].locality) {
-               url += "&";
-               url += "in_csz=" + hcalendar.location.adr[j].locality;
-               if (hcalendar.location.adr[j].region) {
-                 url += ", ";
-                 url += hcalendar.location.adr[j].region;
-               }
-               if (hcalendar.location.adr[j]["postal-code"]) {
-                 url += " ";
-                 url += hcalendar.location.adr[j]["postal-code"];
-               }
-             }
-		  }
+          if (hcalendar.location.adr) {
+            if (hcalendar.location.adr[j]) {
+              if (hcalendar.location.adr[j]["street-address"]) {
+                url += "&";
+                url += "in_st=" + encodeURIComponent(hcalendar.location.adr[j]["street-address"][0]);
+              }
+              if (hcalendar.location.adr[j].locality) {
+                url += "&";
+                url += "in_csz=" + hcalendar.location.adr[j].locality;
+                if (hcalendar.location.adr[j].region) {
+                  url += ", ";
+                  url += hcalendar.location.adr[j].region;
+                }
+                if (hcalendar.location.adr[j]["postal-code"]) {
+                  url += " ";
+                  url += hcalendar.location.adr[j]["postal-code"];
+                }
+              }
+            }
+          }
         } else {
           url += "&";
           url += "in_loc=" + hcalendar.location;

--- a/install.rdf
+++ b/install.rdf
@@ -12,6 +12,7 @@
         <em:contributor>David I. Lehn</em:contributor>
         <em:contributor>Keith Alexander</em:contributor>
         <em:contributor>Daniel O'Connor</em:contributor>
+        <em:contributor>Peter Janes</em:contributor>
         <em:homepageURL>http://www.kaply.com/weblog/operator/</em:homepageURL>
         <em:optionsURL>chrome://operator/content/operator_options.xul</em:optionsURL>
         <em:iconURL>chrome://operator/content/operator_icon.png</em:iconURL>

--- a/install.rdf
+++ b/install.rdf
@@ -3,7 +3,7 @@
     <Description about="urn:mozilla:install-manifest">
         <em:id>{95C9A302-8557-4052-91B7-2BB6BA33C885}</em:id>
         <em:name>Operator</em:name>
-        <em:version>0.9.5.7</em:version>
+        <em:version>0.9.5.8</em:version>
         <em:description></em:description>
         <em:creator>Michael Kaply (IBM)</em:creator>
         <em:contributor>Andy Mitchell</em:contributor>


### PR DESCRIPTION
- Doesn't dereference hcalendar.location.adr[j] if .adr doesn't exist.
- Also fixes a syntax error (unclosed backticks) in the build script.
